### PR TITLE
Refactor to generalize and increase readability and performance 

### DIFF
--- a/lib/string-direction.rb
+++ b/lib/string-direction.rb
@@ -1,3 +1,3 @@
-require_relative 'string-direction/string-direction'
+require_relative './string-direction/string-direction'
 
 String.send :include, StringDirection

--- a/lib/string-direction/string-direction.rb
+++ b/lib/string-direction/string-direction.rb
@@ -2,11 +2,13 @@
 
 # Module with all the logic for automatic detection of text direction. It will be included in String class.
 module StringDirection
-  # left-to-right unicode mark
-  LTR_MARK = "\u200e"
+  LTR_MARK = "\u200e".freeze # left-to-right unicode mark
+  RTL_MARK = "\u200f".freeze # right-to-left unicode mark
 
-  # right-to-left unicode mark
-  RTL_MARK = "\u200f"
+  # Regular expressions used to match direction markers
+  LTR_MARK_REGEX    = /#{LTR_MARK}/.freeze # String contains a LTR marker
+  RTL_MARK_REGEX    = /#{RTL_MARK}/.freeze # String contains a RTL marker
+  CHAR_IGNORE_REGEX = /[\p{M}\p{P}\p{S}\p{Z}\p{C}]/.freeze # ignore unicode marks, punctuations, symbols, separator and other general categories
 
   # returns the direction in which a string is written
   #
@@ -54,14 +56,14 @@ module StringDirection
   #
   # @return [Boolean] true if it containts ltr mark, false otherwise
   def has_ltr_mark?
-    match(/^(.*)#{LTR_MARK}(.*)$/) ? true : false
+    match(LTR_MARK_REGEX) ? true : false
   end
 
   # returns whether string contains the unicode right-to-left mark
   #
   # @return [Boolean] true if it containts rtl mark, false otherwise
   def has_rtl_mark?
-    match(/^(.*)#{RTL_MARK}(.*)$/) ? true : false
+    match(RTL_MARK_REGEX) ? true : false
   end
 
   # returns whether string contains some right-to-left character
@@ -76,7 +78,7 @@ module StringDirection
   # @return [Boolean] true if it containts ltr characters, false otherwise
   def has_ltr_characters?
     # ignore unicode marks, punctuations, symbols, separator and other general categories
-    gsub(/[\p{M}\p{P}\p{S}\p{Z}\p{C}]/, '').match(/[^#{StringDirection::join_scripts_for_regexp(StringDirection.rtl_scripts)}]/) ? true : false
+    gsub(CHAR_IGNORE_REGEX, '').match(/[^#{StringDirection::join_scripts_for_regexp(StringDirection.rtl_scripts)}]/) ? true : false
   end
 
   class << self

--- a/lib/string-direction/string-direction.rb
+++ b/lib/string-direction/string-direction.rb
@@ -15,6 +15,27 @@ module StringDirection
   RTL  = 'rtl'.freeze
   LTR  = 'ltr'.freeze
 
+  class << self
+    attr_accessor :rtl_scripts
+
+    # hook that is called when the module is included and that initializes rtl_scripts
+    #
+    # @param [Module] base The base module from within current module is included
+    def included(base)
+      @rtl_scripts = %w[Arabic Hebrew Nko Kharoshthi Phoenician Syriac Thaana Tifinagh]
+    end
+
+    # given an array of script names, which should be supported by Ruby {http://www.ruby-doc.org/core-1.9.3/Regexp.html#label-Character+Properties regular expression properties}, returns a string where all of them are concatenaded inside a "\\p{}" construction
+    #
+    # @param [Array] scripts the array of script names
+    # @return [String] the script names joined ready to be used in the construction of a regular expression
+    # @example
+    #   StringDirection.join_scripts_for_regexp(%w[Arabic Hebrew]) #=> "\p{Arabic}\p{Hebrew}"
+    def join_scripts_for_regexp(scripts)
+      scripts.map { |script| '\p{'+script+'}' }.join
+    end
+  end
+
   # returns the direction in which a string is written
   #
   # @return ["ltr"] if it's a left-to-right string
@@ -91,26 +112,5 @@ module StringDirection
 
   def joined_scripts_for_regex
     StringDirection::join_scripts_for_regexp(StringDirection.rtl_scripts)
-  end
-
-  class << self
-    attr_accessor :rtl_scripts
-
-    # hook that is called when the module is included and that initializes rtl_scripts
-    #
-    # @param [Module] base The base module from within current module is included
-    def included(base)
-      @rtl_scripts = %w[Arabic Hebrew Nko Kharoshthi Phoenician Syriac Thaana Tifinagh]
-    end
-
-    # given an array of script names, which should be supported by Ruby {http://www.ruby-doc.org/core-1.9.3/Regexp.html#label-Character+Properties regular expression properties}, returns a string where all of them are concatenaded inside a "\\p{}" construction
-    #
-    # @param [Array] scripts the array of script names
-    # @return [String] the script names joined ready to be used in the construction of a regular expression
-    # @example
-    #   StringDirection.join_scripts_for_regexp(%w[Arabic Hebrew]) #=> "\p{Arabic}\p{Hebrew}"
-    def join_scripts_for_regexp(scripts)
-      scripts.map { |script| '\p{'+script+'}' }.join
-    end
   end
 end

--- a/lib/string-direction/string-direction.rb
+++ b/lib/string-direction/string-direction.rb
@@ -10,6 +10,11 @@ module StringDirection
   RTL_MARK_REGEX    = /#{RTL_MARK}/.freeze # String contains a RTL marker
   CHAR_IGNORE_REGEX = /[\p{M}\p{P}\p{S}\p{Z}\p{C}]/.freeze # ignore unicode marks, punctuations, symbols, separator and other general categories
 
+  # direction strings that get passed around
+  BIDI = 'bidi'.freeze
+  RTL  = 'rtl'.freeze
+  LTR  = 'ltr'.freeze
+
   # returns the direction in which a string is written
   #
   # @return ["lft"] if it's a left-to-right string
@@ -17,17 +22,17 @@ module StringDirection
   # @return ["bidi"] if it's a bi-directinal string
   def direction
     if has_ltr_mark? and has_rtl_mark?
-      'bidi'
+      BIDI
     elsif has_ltr_mark?
-      'ltr'
+      LTR
     elsif has_rtl_mark?
-      'rtl'
+      RTL
     elsif not has_rtl_characters?
-      'ltr'
+      LTR
     elsif has_ltr_characters?
-      'bidi'
+      BIDI
     else
-      'rtl'
+      RTL
     end
   end
 
@@ -35,21 +40,21 @@ module StringDirection
   #
   # @return [Boolean] true if it is a left-to-right string, false otherwise
   def is_ltr?
-    (direction == 'ltr') ? true : false
+    (direction == LTR) ? true : false
   end
 
   # whether string is a right-to-left one
   #
   # @return [Boolean] true if it is a right-to-left string, false otherwise
   def is_rtl?
-    (direction == 'rtl') ? true : false
+    (direction == RTL) ? true : false
   end
 
   # whether string is a bi-directional one
   #
   # @return [Boolean] true if it is a bi-directional string, false otherwise
   def is_bidi?
-    (direction == 'bidi') ? true : false
+    (direction == BIDI) ? true : false
   end
 
   # returns whether string contains the unicode left-to-right mark

--- a/lib/string-direction/string-direction.rb
+++ b/lib/string-direction/string-direction.rb
@@ -17,17 +17,17 @@ module StringDirection
 
   # returns the direction in which a string is written
   #
-  # @return ["lft"] if it's a left-to-right string
+  # @return ["ltr"] if it's a left-to-right string
   # @return ["rtl"] if it's a right-to-left string
   # @return ["bidi"] if it's a bi-directinal string
   def direction
-    if has_ltr_mark? and has_rtl_mark?
+    if has_ltr_mark? !! has_rtl_mark?
       BIDI
     elsif has_ltr_mark?
       LTR
     elsif has_rtl_mark?
       RTL
-    elsif not has_rtl_characters?
+    elsif !has_rtl_characters?
       LTR
     elsif has_ltr_characters?
       BIDI

--- a/lib/string-direction/string-direction.rb
+++ b/lib/string-direction/string-direction.rb
@@ -75,7 +75,8 @@ module StringDirection
   #
   # @return [Boolean] true if it containts rtl characters, false otherwise
   def has_rtl_characters?
-    !!match(/[#{StringDirection::join_scripts_for_regexp(StringDirection.rtl_scripts)}]/)
+    # ignore unicode marks, punctuations, symbols, separator and other general categories
+    !!gsub(CHAR_IGNORE_REGEX, '').match(/[#{joined_scripts_for_regex}]/)
   end
 
   # returns whether string contains some left-to-right character
@@ -83,7 +84,13 @@ module StringDirection
   # @return [Boolean] true if it containts ltr characters, false otherwise
   def has_ltr_characters?
     # ignore unicode marks, punctuations, symbols, separator and other general categories
-    !!gsub(CHAR_IGNORE_REGEX, '').match(/[^#{StringDirection::join_scripts_for_regexp(StringDirection.rtl_scripts)}]/)
+    !!gsub(CHAR_IGNORE_REGEX, '').match(/[^#{joined_scripts_for_regex}]/)
+  end
+
+  private
+
+  def joined_scripts_for_regex
+    StringDirection::join_scripts_for_regexp(StringDirection.rtl_scripts)
   end
 
   class << self

--- a/lib/string-direction/string-direction.rb
+++ b/lib/string-direction/string-direction.rb
@@ -21,7 +21,7 @@ module StringDirection
   # @return ["rtl"] if it's a right-to-left string
   # @return ["bidi"] if it's a bi-directinal string
   def direction
-    if has_ltr_mark? !! has_rtl_mark?
+    if has_ltr_mark? && has_rtl_mark?
       BIDI
     elsif has_ltr_mark?
       LTR
@@ -40,42 +40,42 @@ module StringDirection
   #
   # @return [Boolean] true if it is a left-to-right string, false otherwise
   def is_ltr?
-    (direction == LTR) ? true : false
+    direction === LTR
   end
 
   # whether string is a right-to-left one
   #
   # @return [Boolean] true if it is a right-to-left string, false otherwise
   def is_rtl?
-    (direction == RTL) ? true : false
+    direction === RTL
   end
 
   # whether string is a bi-directional one
   #
   # @return [Boolean] true if it is a bi-directional string, false otherwise
   def is_bidi?
-    (direction == BIDI) ? true : false
+    direction === BIDI
   end
 
   # returns whether string contains the unicode left-to-right mark
   #
   # @return [Boolean] true if it containts ltr mark, false otherwise
   def has_ltr_mark?
-    match(LTR_MARK_REGEX) ? true : false
+    !!match(LTR_MARK_REGEX)
   end
 
   # returns whether string contains the unicode right-to-left mark
   #
   # @return [Boolean] true if it containts rtl mark, false otherwise
   def has_rtl_mark?
-    match(RTL_MARK_REGEX) ? true : false
+    !!match(RTL_MARK_REGEX)
   end
 
   # returns whether string contains some right-to-left character
   #
   # @return [Boolean] true if it containts rtl characters, false otherwise
   def has_rtl_characters?
-    match(/[#{StringDirection::join_scripts_for_regexp(StringDirection.rtl_scripts)}]/) ? true : false
+    !!match(/[#{StringDirection::join_scripts_for_regexp(StringDirection.rtl_scripts)}]/)
   end
 
   # returns whether string contains some left-to-right character
@@ -83,7 +83,7 @@ module StringDirection
   # @return [Boolean] true if it containts ltr characters, false otherwise
   def has_ltr_characters?
     # ignore unicode marks, punctuations, symbols, separator and other general categories
-    gsub(CHAR_IGNORE_REGEX, '').match(/[^#{StringDirection::join_scripts_for_regexp(StringDirection.rtl_scripts)}]/) ? true : false
+    !!gsub(CHAR_IGNORE_REGEX, '').match(/[^#{StringDirection::join_scripts_for_regexp(StringDirection.rtl_scripts)}]/)
   end
 
   class << self

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,1 @@
 require_relative '../lib/string-direction'
-
-RSpec.configure do |c|
-  c.treat_symbols_as_metadata_keys_with_true_values = true
-end

--- a/spec/string/string_spec.rb
+++ b/spec/string/string_spec.rb
@@ -8,29 +8,29 @@ describe String do
     context "when marks are present" do
       it "should return 'ltr' if it contains the left-to-right mark and no right-to-left mark" do
         string = String::LTR_MARK+english
-        string.direction.should eql 'ltr'
+        expect(string.direction).to eql 'ltr'
       end
       it "should return 'rtl' if it contains the right-to-left mark and no left-to-right mark" do
         string = String::RTL_MARK+arabic
-        string.direction.should eql 'rtl'
+        expect(string.direction).to eql 'rtl'
       end
       it "should return 'bidi' if it contains both the left-to-right mark and the right-to-left mark" do
         string = String::LTR_MARK+english+String::RTL_MARK+arabic
-        string.direction.should eql 'bidi'
+        expect(string.direction).to eql 'bidi'
       end
     end
     context "when marks are not present" do
       it "should return 'ltr' if no right-to-left character is present" do
         string = english
-        string.direction.should eql 'ltr'
+        expect(string.direction).to eql 'ltr'
       end
       it "should return 'rtl' if only right-to-left character are present" do
         string = arabic
-        string.direction.should eql 'rtl'
+        expect(string.direction).to eql 'rtl'
       end
       it "should return 'bidi' if both left-to-right and right-to-left characters are present" do
         string = arabic+' '+english
-        string.direction.should eql 'bidi'
+        expect(string.direction).to eql 'bidi'
       end
     end
     context "when default rtl scripts are changed" do
@@ -39,12 +39,12 @@ describe String do
       it "should return 'rtl' if there are characters for an added right-to-left script and no marks characters are present" do
         StringDirection.rtl_scripts << new_rtl_script
         string = english
-        string.direction.should eql 'rtl'
+        expect(string.direction).to eql 'rtl'
       end
       it "should return 'ltr' if there are characters for a deleted right-to-left script (so now ltr) and no mark characters are present" do
         StringDirection.rtl_scripts.delete old_rtl_script
         string = arabic
-        string.direction.should eql 'ltr'
+        expect(string.direction).to eql 'ltr'
       end
       after :each do
         StringDirection.rtl_scripts.delete new_rtl_script if StringDirection.rtl_scripts.include? new_rtl_script
@@ -58,7 +58,7 @@ describe String do
           separator = " "
           other = "\u0005"
           string = arabic+mark+punctuation+symbol+separator+other
-          string.direction.should eql 'rtl'
+          expect(string.direction).to eql 'rtl'
         end
       end
     end
@@ -66,31 +66,31 @@ describe String do
   describe "#is_ltr?" do
     it "should return true if it is a left-to-right string" do
       string = english
-      string.is_ltr?.should be_true
+      expect(string.is_ltr?).to be true
     end
     it "should return false if it is not a left-to-right string" do
       string = arabic
-      string.is_ltr?.should be_false
+      expect(string.is_ltr?).to be false
     end
   end
   describe "#is_rtl?" do
     it "should return true if it is a right-to-left string" do
       string = arabic
-      string.is_rtl?.should be_true
+      expect(string.is_rtl?).to be true
     end
     it "should return false if it is not a right-to-left string" do
       string = english
-      string.is_rtl?.should be_false
+      expect(string.is_rtl?).to be false
     end
   end
   describe "#is_bidi?" do
     it "should return true if it is a bi-directional string" do
       string = english+' '+arabic
-      string.is_bidi?.should be_true
+      expect(string.is_bidi?).to be true
     end
     it "should return false if it is not a bi-directional string" do
       string = english
-      string.is_bidi?.should be_false
+      expect(string.is_bidi?).to be false
     end
   end
 end

--- a/string-direction.gemspec
+++ b/string-direction.gemspec
@@ -10,7 +10,6 @@ Gem::Specification.new do |s|
    s.files = `git ls-files`.split("\n")
 
    s.add_runtime_dependency "yard", "~>0.8"
-   s.add_runtime_dependency "redcarpet", "~>2.2"
 
    s.add_development_dependency "rspec", "~>2.13"
 end


### PR DESCRIPTION
- Define constants to be passed around rather than redefining the string literal each time
- Define static regex as frozen constants
- Remove unused character groups from regex
- use a relative path in `require_relative`
- put class methods at top of class, rather than bottom. This is the standard afaik
- use `===` rather than the ternary operator
- use `!!match(...)` rather than the ternary operator
- extract joining call into private method because it is long and used more than once
- make both ltr and rtl character detection ignore certain character sets
- update rspec test syntax to avoid deprecation warnings
- rename the gem spec file to `.gemspec` instead of `.spec`
- remove redcarpet dependency from the gemspec as it appears to be unused?