### PR TITLE
Add dominant sections strategy

### DIFF
--- a/lib/string-direction.rb
+++ b/lib/string-direction.rb
@@ -4,6 +4,7 @@ require 'string-direction/detector'
 require 'string-direction/strategy'
 require 'string-direction/strategies/marks_strategy'
 require 'string-direction/strategies/characters_strategy'
+require 'string-direction/strategies/dominant_sections_strategy'
 require 'string-direction/string_methods'
 
 # Constants & configuration common in the whole library

--- a/lib/string-direction/strategies/characters_strategy.rb
+++ b/lib/string-direction/strategies/characters_strategy.rb
@@ -19,17 +19,15 @@ module StringDirection
       end
     end
 
-    protected
+    private
 
     def rtl_regex
-      /[#{join_rtl_for_regex}]/
+      @rtl_regex ||= /[#{rtl_script_character_classes}]/
     end
 
     def ltr_regex
-      /[^#{join_rtl_for_regex}#{IGNORED_CHARS}]/
+      @ltr_regex ||= /[^#{rtl_script_character_classes}#{IGNORED_CHARS}]/
     end
-
-    private
 
     def rtl_characters?(string)
       string.match(rtl_regex)
@@ -39,8 +37,8 @@ module StringDirection
       string.match(ltr_regex)
     end
 
-    def join_rtl_for_regex
-      rtl_scripts.map { |script| "\\p{#{script}}" }.join
+    def rtl_script_character_classes
+      @rtl_script_character_classes ||= rtl_scripts.map { |script| "\\p{#{script}}" }.join
     end
 
     def rtl_scripts

--- a/lib/string-direction/strategies/characters_strategy.rb
+++ b/lib/string-direction/strategies/characters_strategy.rb
@@ -2,7 +2,7 @@ module StringDirection
   # Strategy to detect direction from the scripts to which string characters belong
   class CharactersStrategy < Strategy
     # Ignored characters: unicode marks, punctuations, symbols, separator and other general categories
-    CHAR_IGNORE_REGEX = /[\p{M}\p{P}\p{S}\p{Z}\p{C}]/.freeze
+    IGNORED_CHARS = '\p{M}\p{P}\p{S}\p{Z}\p{C}'.freeze
 
     # Inspect to wich scripts characters belongs and  infer from them the string direction. right-to-left scripts are those in {Configuration#rtl_scripts}
     #
@@ -19,18 +19,28 @@ module StringDirection
       end
     end
 
+    protected
+
+    def rtl_regex
+      /[#{join_rtl_for_regex}]/
+    end
+
+    def ltr_regex
+      /[^#{join_rtl_for_regex}#{IGNORED_CHARS}]/
+    end
+
     private
 
     def rtl_characters?(string)
-      string.match(/[#{join_rtl_for_regex}]/)
+      string.match(rtl_regex)
     end
 
     def ltr_characters?(string)
-      string.gsub(CHAR_IGNORE_REGEX, '').match(/[^#{join_rtl_for_regex}]/)
+      string.match(ltr_regex)
     end
 
     def join_rtl_for_regex
-      rtl_scripts.map { |script| '\p{' + script + '}' }.join
+      rtl_scripts.map { |script| "\\p{#{script}}" }.join
     end
 
     def rtl_scripts

--- a/lib/string-direction/strategies/dominant_sections_strategy.rb
+++ b/lib/string-direction/strategies/dominant_sections_strategy.rb
@@ -1,0 +1,51 @@
+module StringDirection
+  # Strategy to detect direction from the scripts to which string characters
+  # belong
+  class DominantSectionsStrategy < CharactersStrategy
+    # Get the length of ltr and rtl sections in the supplied string and
+    # infer the direction from which type of section is the most common.
+    # An rtl section starts with an rtl character and ends with an ltr character
+    # An ltr section starts with an ltr character and ends with an rtl character
+    #
+    # params [String] The string to inspect
+    # @return [String, nil]
+    def run(string)
+      @s = string.to_s
+      counts = Hash.new(0)
+      each_section do |type, length|
+        counts[type] += length
+      end
+      return nil if counts[ltr] == counts[rtl]
+      counts.max_by { |_k, v| v }.first
+    end
+
+    # yields once for each ltr / rtl "section" in the string, with the type
+    # being ltr or rtl and length being the length of the section
+    def each_section
+      # find the start of the first section - the first ltr / rtl character
+      starts = { ltr => next_ltr_character(0), rtl => next_rtl_character(0) }
+      type, start = starts.reject { |_k, v| v.nil? }.min_by { |_k, v| v }
+      # neither rtl / ltr were found
+      return if start.nil?
+      loop do
+        # if the current section is ltr then it finishes at the next rtl character
+        finish = type == ltr ? next_rtl_character(start) : next_ltr_character(start)
+        break if finish.nil?
+        yield type, finish - start
+        type = type == ltr ? rtl : ltr
+        start = finish
+      end
+      yield type, @s.length - start
+    end
+
+    private
+
+    def next_ltr_character(i)
+      @s.match(ltr_regex, i) { |m| m.begin(0) }
+    end
+
+    def next_rtl_character(i)
+      @s.match(rtl_regex, i) { |m| m.begin(0) }
+    end
+  end
+end

--- a/spec/string-direction/strategies/dominant_sections_strategy_spec.rb
+++ b/spec/string-direction/strategies/dominant_sections_strategy_spec.rb
@@ -1,0 +1,115 @@
+require 'spec_helper'
+
+describe StringDirection::DominantSectionsStrategy do
+  describe '#run' do
+    let(:english) { 'English' }
+    let(:arabic) { 'العربية' }
+
+    subject { described_class.new.run(string) }
+
+    context 'when both left-to-right and right-to-left characters are present in equal numbers' do
+      let(:string) { arabic + english }
+
+      it "returns nil" do
+        expect(subject).to eq nil
+      end
+    end
+
+    context 'when both left-to-right and right-to-left characters are present, with more ltr' do
+      let(:string) { english + arabic + english }
+
+      it "returns 'ltr'" do
+        expect(subject).to eq 'ltr'
+      end
+    end
+
+    context 'when right-to-left character are present but none of left-to-right' do
+      let(:string) { arabic }
+
+      it "returns 'rtl'" do
+        expect(subject).to eq 'rtl'
+      end
+    end
+
+    context 'when left-to-right character are present but none of right-to-left' do
+      let(:string) { english }
+
+      it "returns 'ltr'" do
+        expect(subject).to eq 'ltr'
+      end
+    end
+
+    context 'when neither left-to-right nor right-to-left characters are present' do
+      let(:string) { ' ' }
+
+      it 'returns nil' do
+        expect(subject).to be_nil
+      end
+    end
+
+    context 'when default right-to-left scripts are changed' do
+      let(:new_rtl_script) { 'Latin' }
+      let(:old_rtl_script) { 'Arabic' }
+
+      context 'when there are characters from an added right-to-left script' do
+        let(:string) { english }
+
+        it 'treats them as right-to-left chracters' do
+          StringDirection.configure do |config|
+            config.rtl_scripts << new_rtl_script
+          end
+
+          expect(subject).to eq 'rtl'
+        end
+      end
+
+      context 'when there are characters from a deleted right-to-left script ' do
+        let(:string) { arabic }
+
+        it 'treats them as left-to-right characters' do
+          StringDirection.configure do |config|
+            config.rtl_scripts.delete(old_rtl_script)
+          end
+
+          expect(subject).to eq 'ltr'
+        end
+      end
+
+      after :each do
+        StringDirection.reset_configuration
+      end
+    end
+
+    context 'when special characters are present' do
+      let(:string) do
+        mark = "\u0903"
+        punctuation = '_'
+        symbol = '€'
+        separator = ' '
+        other = "\u0005"
+
+        arabic + mark + punctuation + symbol + separator + other
+      end
+
+      it 'ignores them' do
+        expect(subject).to eq 'rtl'
+      end
+    end
+
+    context 'when an object responding to #to_s is given' do
+      let(:string) do
+        class StringDirection::TestObject
+          def to_s
+            'English'
+          end
+        end
+
+        StringDirection::TestObject.new
+      end
+
+      it 'takes as string the result of #to_s method' do
+        expect(subject).to eq('ltr')
+      end
+    end
+  end
+end


### PR DESCRIPTION
I need to be able to detect the dominant direction of a bidirectional string which contains mostly one direction, but some small sections of other scripts (e.g. a document with quotes taken from different scripts). The strings I'm using can be very large and are mainly in a single script, so I've used an approach optimised for that.

- Added methods for the regexes of the characters strategy so the subclasses can access them
- Memoized the regexes for the characters strategy to improve performance
- Added a dominant sections strategy to allow for bidirectional strings which are mostly in a single script
- Improved the performance and memory usage of the ltr character detection (by using a single regex without any gsub)
